### PR TITLE
Get rid of repeated SDK version checks

### DIFF
--- a/processor/src/main/java/de/devland/esperandro/processor/EsperandroAnnotationProcessor.java
+++ b/processor/src/main/java/de/devland/esperandro/processor/EsperandroAnnotationProcessor.java
@@ -262,7 +262,7 @@ public class EsperandroAnnotationProcessor extends AbstractProcessor {
         writer.emitAnnotation(SuppressLint.class, "{\"NewApi\", \"CommitPrefEdits\"}");
         writer.beginMethod("void", "remove", Constants.MODIFIER_PUBLIC, String.class.getName(), "key");
         StringBuilder statementPattern = new StringBuilder().append("preferences.edit().remove(key).%s");
-        PreferenceEditorCommitStyle.emitPreferenceCommitActionWithVersionCheck(writer,
+        PreferenceEditorCommitStyle.emitPreferenceCommitAction(writer,
                 PreferenceEditorCommitStyle.APPLY, statementPattern);
         writer.endMethod();
         writer.emitEmptyLine();
@@ -285,7 +285,7 @@ public class EsperandroAnnotationProcessor extends AbstractProcessor {
         writer.emitAnnotation(SuppressLint.class, "{\"NewApi\", \"CommitPrefEdits\"}");
         writer.beginMethod("void", "clear", Constants.MODIFIER_PUBLIC);
         statementPattern = new StringBuilder().append("preferences.edit().clear().%s");
-        PreferenceEditorCommitStyle.emitPreferenceCommitActionWithVersionCheck(writer,
+        PreferenceEditorCommitStyle.emitPreferenceCommitAction(writer,
                 PreferenceEditorCommitStyle.APPLY, statementPattern);
         writer.endMethod();
         writer.emitEmptyLine();
@@ -300,7 +300,7 @@ public class EsperandroAnnotationProcessor extends AbstractProcessor {
         for (String preferenceName : preferenceNames) {
             writer.emitStatement("editor.remove(\"%s\")", preferenceName);
         }
-        PreferenceEditorCommitStyle.emitPreferenceCommitActionWithVersionCheck(writer,
+        PreferenceEditorCommitStyle.emitPreferenceCommitAction(writer,
                 PreferenceEditorCommitStyle.APPLY, new StringBuilder("editor.%s"));
         writer.endMethod();
         writer.emitEmptyLine();

--- a/processor/src/main/java/de/devland/esperandro/processor/PreferenceEditorCommitStyle.java
+++ b/processor/src/main/java/de/devland/esperandro/processor/PreferenceEditorCommitStyle.java
@@ -18,20 +18,11 @@ public enum PreferenceEditorCommitStyle {
         return statementPart;
     }
 
-    public static void emitPreferenceCommitActionWithVersionCheck(JavaWriter writer,
-                                                                  PreferenceEditorCommitStyle commitStyle,
-                                                                  StringBuilder statementPattern) throws IOException {
-        if (commitStyle.equals(PreferenceEditorCommitStyle.APPLY)) {
-            writer.beginControlFlow("if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD)");
-            String statement = String.format(statementPattern.toString(), PreferenceEditorCommitStyle.COMMIT
-                    .getStatementPart());
-            writer.emitStatement(statement);
-            writer.nextControlFlow("else");
-        }
+    public static void emitPreferenceCommitAction(JavaWriter writer,
+                                                  PreferenceEditorCommitStyle commitStyle,
+                                                  StringBuilder statementPattern) throws IOException {
+
         String statement = String.format(statementPattern.toString(), commitStyle.getStatementPart());
         writer.emitStatement(statement);
-        if (commitStyle.equals(PreferenceEditorCommitStyle.APPLY)) {
-            writer.endControlFlow();
-        }
     }
 }

--- a/processor/src/main/java/de/devland/esperandro/processor/PutterGenerator.java
+++ b/processor/src/main/java/de/devland/esperandro/processor/PutterGenerator.java
@@ -157,7 +157,7 @@ public class PutterGenerator {
         // only use apply on API >= 9
         StringBuilder baseStatement = new StringBuilder().append(String.format(statementPattern.toString(),
                 methodSuffix, valueName, value)).append(".%s");
-        PreferenceEditorCommitStyle.emitPreferenceCommitActionWithVersionCheck(writer, commitStyle, baseStatement);
+        PreferenceEditorCommitStyle.emitPreferenceCommitAction(writer, commitStyle, baseStatement);
         writer.endMethod();
         writer.emitEmptyLine();
     }


### PR DESCRIPTION
Thanks for creating this project. We're using it in our and and we're quite happy with it.

There's one thing I'd like to get rid of if possible. In all of the editing calls, since #11, there's a check of the current SDK version to see if it's possible to call `apply()`:

    @Override
    @SuppressLint("NewApi")
    public void registrationId(String registrationId) {
      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
        preferences.edit().putString("registrationId", registrationId).commit();
      } else {
        preferences.edit().putString("registrationId", registrationId).apply();
      }
    }

Our app is has a minSdkVersion of 15, so these calls are useless. I figure there are three ways to get rid of them:

1. Generate 2 implementations of the preference interface: one for Gingerbread containing `apply()` and one for pre-Gingerbread containing `commit()`. In the constructor of `Esperandro`, the current SDK could be checked and the suffix could be determined to be `$$GingerbreadImpl` or `$$PreGingerbreadImpl`. The benefit of this approach is that there would only be one SDK check per execution. The downside is that there would be twice as many classes generated and deployed with the APK. A note could be added to the README with the necessary ProGuard lines to delete the pre-Gingerbread implementations if the minSdkVersion is 9 or above.

2. Instead of, or in addition to approach 1 would be to detect the minSdkVersion in the annotation processor and not generate the `commit()` calls if the minSdkVersion is 9 or above. I'm not sure how easy it is to get the minSdkVersion from the processor, so this might be impossible.

3. Just get rid of the calls to `commit()` completely and say that Esperandro can only be used when minSdkVersion is 9 or above. :-)

If you have a preferred approach, I'd be willing to implement it if it would be merged.